### PR TITLE
chore(FOM-130): stop deploying this repo, switch remaining auth to OIDC

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -90,6 +90,9 @@ jobs:
       - Build-lambda-twitch-event-sub-webhook
       - Build-lambda-twitch-record-manager
       - Build-lambda-timestream-query
+    permissions:
+      id-token: write
+      contents: read
     uses: fomiller/gh-actions/.github/workflows/terragrunt.yaml@main
     with:
       environment: ${{ contains(fromJSON('["refs/heads/main", "refs/heads/master"]'), github.ref) && 'prod' || 'dev' }}
@@ -97,16 +100,22 @@ jobs:
       doppler-project: chat-stat
       download-artifacts: true
       artifacts_dir: infra/modules/aws/lambda/bin
+      use-oidc: true
     secrets: inherit
         
   Build-chat-stat-logger-image:
     name: 'Build/Deploy ECR chat-stat-logger image'
     needs: Deploy-infra
+    permissions:
+      id-token: write
+      contents: read
+      pull-requests: read
     uses: fomiller/gh-actions/.github/workflows/ecr.yaml@main
     with:
       environment: ${{ contains(fromJSON('["refs/heads/main", "refs/heads/master"]'), github.ref) && 'prod' || 'dev' }}
       repo: logger
       repo-prefix: "fomiller-chat-stat"
+      use-oidc: true
       src-filters: |
         docker:
           - 'dockerfile'
@@ -117,11 +126,16 @@ jobs:
   Build-chat-stat-api-image:
     name: 'Build/Deploy ECR chat-stat-api image'
     needs: Deploy-infra
+    permissions:
+      id-token: write
+      contents: read
+      pull-requests: read
     uses: fomiller/gh-actions/.github/workflows/ecr.yaml@main
     with:
       environment: ${{ contains(fromJSON('["refs/heads/main", "refs/heads/master"]'), github.ref) && 'prod' || 'dev' }}
       repo: api
       repo-prefix: "fomiller-chat-stat"
+      use-oidc: true
       dockerfile: dockerfile.api
       platforms: '["linux/amd64"]'
       src-filters: |
@@ -133,11 +147,16 @@ jobs:
   Build-chat-stat-frontend-image:
     name: 'Build/Deploy ECR chat-stat-frontend image'
     needs: Deploy-infra
+    permissions:
+      id-token: write
+      contents: read
+      pull-requests: read
     uses: fomiller/gh-actions/.github/workflows/ecr.yaml@main
     with:
       environment: ${{ contains(fromJSON('["refs/heads/main", "refs/heads/master"]'), github.ref) && 'prod' || 'dev' }}
       repo: frontend
       repo-prefix: "fomiller-chat-stat"
+      use-oidc: true
       dockerfile: dockerfile.frontend
       platforms: '["linux/amd64"]'
       src-filters: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,17 +2,10 @@
 
 name: 'Terragrunt Deploy'
   
+# Manual only. This repo isn't deployed anymore and its AWS infra is being torn
+# down (FOM-132), so a push must not apply terraform.
 on:
-  push:
-    paths:
-      - '.github/**'
-      - 'modules/**'
-      - 'infra/**'
-      - 'src/**'
-      - 'justfile'
-      - 'dockerfile*'
-      - 'go.mod'
-      - 'go.sum'
+  workflow_dispatch:
    
 jobs:
   Pre-check:


### PR DESCRIPTION
Turns off the automatic deploy. The workflow is `workflow_dispatch` only now, so a push doesn't apply terraform.

Also carries the [FOM-130](https://linear.app/fomiller/issue/FOM-130/move-ci-to-github-oidc-federated-roles) OIDC change, so if it ever is run by hand it uses the federated role instead of static keys. That matters because the IAM users and their keys are being deleted.

Teardown of what's left in AWS is [FOM-132](https://linear.app/fomiller/issue/FOM-132/tear-down-dungeons-and-llamas-aws-infra).